### PR TITLE
Add xAI Finance Agent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # AI_Finance
+
+This repository contains an implementation of the **xAI Finance Agent** example from [Shubhamsaboo/awesome-llm-apps](https://github.com/Shubhamsaboo/awesome-llm-apps). The agent provides real-time financial analysis using xAI's Grok model, YFinance for stock data, and DuckDuckGo for web search. The code lives in [`xai_finance_agent/`](xai_finance_agent/).
+
+## Quickstart
+```bash
+pip install -r xai_finance_agent/requirements.txt
+export XAI_API_KEY="<your api key>"
+python xai_finance_agent/xai_finance_agent.py
+```

--- a/xai_finance_agent/README.md
+++ b/xai_finance_agent/README.md
@@ -1,0 +1,28 @@
+## 📊 AI Finance Agent with xAI Grok
+This application creates a financial analysis agent powered by xAI's Grok model, combining real-time stock data with web search capabilities. It provides structured financial insights through an interactive playground interface.
+
+### Features
+- Powered by xAI's Grok-beta model
+- Real-time stock data analysis via YFinance
+- Web search capabilities through DuckDuckGo
+- Formatted output with tables for financial data
+- Interactive playground interface
+
+### How to get Started?
+1. Clone the GitHub repository
+```bash
+git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+cd awesome-llm-apps/ai_agent_tutorials/xai_finance_agent
+```
+2. Install the required dependencies:
+```bash
+pip install -r requirements.txt
+```
+3. Get your xAI API Key and export it as an environment variable:
+```bash
+export XAI_API_KEY='your-api-key-here'
+```
+4. Run the agent:
+```bash
+python xai_finance_agent.py
+```

--- a/xai_finance_agent/requirements.txt
+++ b/xai_finance_agent/requirements.txt
@@ -1,0 +1,5 @@
+agno
+duckduckgo-search
+yfinance
+fastapi[standard]
+openai

--- a/xai_finance_agent/xai_finance_agent.py
+++ b/xai_finance_agent/xai_finance_agent.py
@@ -1,0 +1,19 @@
+from agno.agent import Agent
+from agno.models.xai import xAI
+from agno.tools.yfinance import YFinanceTools
+from agno.tools.duckduckgo import DuckDuckGoTools
+from agno.playground import Playground, serve_playground_app
+
+agent = Agent(
+    name="xAI Finance Agent",
+    model=xAI(id="grok-beta"),
+    tools=[DuckDuckGoTools(), YFinanceTools(stock_price=True, analyst_recommendations=True, stock_fundamentals=True)],
+    instructions=["Always use tables to display financial/numerical data. For text data use bullet points and small paragrpahs."],
+    show_tool_calls=True,
+    markdown=True,
+)
+
+app = Playground(agents=[agent]).get_app()
+
+if __name__ == "__main__":
+    serve_playground_app("xai_finance_agent:app", reload=True)


### PR DESCRIPTION
## Summary
- implement xAI Finance Agent example from awesome-llm-apps
- document quickstart instructions

## Testing
- `python xai_finance_agent/xai_finance_agent.py` *(fails: blocked connection to api.agno.com)*

------
https://chatgpt.com/codex/tasks/task_e_6853247e10288332b6dbda3f71fbfd21