### PR TITLE
Add Gradio interface to finance agent

### DIFF
--- a/xai_finance_agent/requirements.txt
+++ b/xai_finance_agent/requirements.txt
@@ -3,3 +3,4 @@ duckduckgo-search
 yfinance
 fastapi[standard]
 openai
+gradio

--- a/xai_finance_agent/xai_finance_agent.py
+++ b/xai_finance_agent/xai_finance_agent.py
@@ -3,6 +3,7 @@ from agno.models.xai import xAI
 from agno.tools.yfinance import YFinanceTools
 from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.playground import Playground, serve_playground_app
+import gradio as gr
 
 agent = Agent(
     name="xAI Finance Agent",
@@ -15,5 +16,15 @@ agent = Agent(
 
 app = Playground(agents=[agent]).get_app()
 
+
+def run_agent(query: str) -> str:
+    """Run the xAI finance agent and return the response as a string."""
+    response = agent.run(query)
+    if hasattr(response, "get_content_as_string"):
+        return response.get_content_as_string()
+    return str(response)
+
+
 if __name__ == "__main__":
-    serve_playground_app("xai_finance_agent:app", reload=True)
+    interface = gr.Interface(fn=run_agent, inputs="text", outputs="text", title="xAI Finance Agent")
+    interface.launch(share=True)


### PR DESCRIPTION
## Summary
- wrap finance agent with a Gradio interface
- launch interface with `share=True`
- add gradio to requirements

## Testing
- `python -m py_compile xai_finance_agent/xai_finance_agent.py`
- `python xai_finance_agent/xai_finance_agent.py` *(fails to create share link)*

------
https://chatgpt.com/codex/tasks/task_e_68532836142c8332a8ae0fc634490b85