### PR TITLE
Fix duplicate run_agent and start agent

### DIFF
--- a/xai_finance_agent/xai_finance_agent.py
+++ b/xai_finance_agent/xai_finance_agent.py
@@ -9,19 +9,10 @@ agent = Agent(
     name="xAI Finance Agent",
     model=xAI(id="grok-beta"),
     tools=[DuckDuckGoTools(), YFinanceTools(stock_price=True, analyst_recommendations=True, stock_fundamentals=True)],
-    instructions=["Always use tables to display financial/numerical data. For text data use bullet points and small paragrpahs."],
+    instructions=["Always use tables to display financial/numerical data. For text data use bullet points and small paragraphs."],
     show_tool_calls=True,
     markdown=True,
 )
-
-def run_agent(query: str) -> str:
-    """Run the xAI finance agent and return the response as a string."""
-    response = agent.run(query)
-    if hasattr(response, "get_content_as_string"):
-        return response.get_content_as_string()
-    return str(response)
-
-
 
 def run_agent(query: str) -> str:
     """Run the xAI finance agent and return the response as a string."""


### PR DESCRIPTION
## Summary
- deduplicate run_agent function
- fix instruction typo in the agent

## Testing
- `python -m py_compile xai_finance_agent/xai_finance_agent.py`
- `python xai_finance_agent/xai_finance_agent.py` *(fails to create share link; server interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68533bd308a08332b15b14eaeb8f9635