### PR TITLE
Switch to Gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # AI_Finance
 
-This repository contains an implementation of the **xAI Finance Agent** example from [Shubhamsaboo/awesome-llm-apps](https://github.com/Shubhamsaboo/awesome-llm-apps). The agent provides real-time financial analysis using xAI's Grok model, YFinance for stock data, and DuckDuckGo for web search. The code lives in [`xai_finance_agent/`](xai_finance_agent/).
+This repository contains an implementation of the **xAI Finance Agent** example from [Shubhamsaboo/awesome-llm-apps](https://github.com/Shubhamsaboo/awesome-llm-apps). The agent provides real-time financial analysis using Google's Gemini model, YFinance for stock data, and DuckDuckGo for web search. The code lives in [`xai_finance_agent/`](xai_finance_agent/).
 
 ## Quickstart
 ```bash
 pip install -r xai_finance_agent/requirements.txt
-export XAI_API_KEY="<your api key>"
+export GOOGLE_API_KEY="<your API key>"
 python xai_finance_agent/xai_finance_agent.py
 ```
 This launches a Gradio chat interface with `share=True` so you can

--- a/xai_finance_agent/README.md
+++ b/xai_finance_agent/README.md
@@ -1,8 +1,8 @@
-## 📊 AI Finance Agent with xAI Grok
-This application creates a financial analysis agent powered by xAI's Grok model, combining real-time stock data with web search capabilities. It provides structured financial insights through a simple Gradio chat interface.
+## 📊 AI Finance Agent with Google Gemini
+This application creates a financial analysis agent powered by Google's Gemini model, combining real-time stock data with web search capabilities. It provides structured financial insights through a simple Gradio chat interface.
 
 ### Features
-- Powered by xAI's Grok-beta model
+- Powered by Google's gemini-pro model
 - Real-time stock data analysis via YFinance
 - Web search capabilities through DuckDuckGo
 - Formatted output with tables for financial data
@@ -18,9 +18,9 @@ cd awesome-llm-apps/ai_agent_tutorials/xai_finance_agent
 ```bash
 pip install -r requirements.txt
 ```
-3. Get your xAI API Key and export it as an environment variable:
+3. Get your Google API key and export it as an environment variable:
 ```bash
-export XAI_API_KEY='your-api-key-here'
+export GOOGLE_API_KEY='your-api-key-here'
 ```
 4. Run the agent to launch a Gradio interface:
 ```bash

--- a/xai_finance_agent/xai_finance_agent.py
+++ b/xai_finance_agent/xai_finance_agent.py
@@ -5,9 +5,11 @@ from agno.agent import Agent
 from agno.tools.yfinance import YFinanceTools
 from agno.tools.duckduckgo import DuckDuckGoTools
 
-# 🔐 Установите ваш ключ Google Gemini
-os.environ["GOOGLE_API_KEY"] = "AIzaSyD-oRb45v1ZuBy9MS4Ho-L-7BiU21qSsAE"
-genai.configure(api_key=os.environ["GOOGLE_API_KEY"])
+# 🔐 Установите ваш ключ Google Gemini в переменную окружения `GOOGLE_API_KEY`
+api_key = os.environ.get("GOOGLE_API_KEY")
+if not api_key:
+    raise EnvironmentError("GOOGLE_API_KEY environment variable not set")
+genai.configure(api_key=api_key)
 
 # ✅ Обёртка для Gemini вместо xAI
 class GeminiModel:


### PR DESCRIPTION
## Summary
- use Google API key from environment and remove hard-coded key
- document the new Gemini backend in both READMEs

## Testing
- `python -m py_compile xai_finance_agent/xai_finance_agent.py`
- `python xai_finance_agent/xai_finance_agent.py` *(fails to share link)*

------
https://chatgpt.com/codex/tasks/task_e_6853b4e4b46c8332a9547827664638a0